### PR TITLE
Bugfix active-count increment

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Return the number of currently idle connections.
 
 Return an available resource from the `pool`. If no open resources available, it makes a new one with a function specified to `make-pool` as `:connector`.
 
-No open resource available and can't open due to the `max-open-count`, this function waits for `:timeout` milliseconds. If `:timeout` specified to `nil`, this waits forever until a new one turns to available.
+No open resource available and can't open due to the `max-open-count`, this function waits for `:timeout` milliseconds. If `:timeout` specified to `nil`, this throws `too-many-open-connection` condition.
 
 ### [Function] putback (object pool)
 

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -139,7 +139,6 @@
                                 :limit (pool-max-open-count pool)))
                    (bt:acquire-lock lock))))
               (let ((item (dequeue storage)))
-                (setf (item-active-p item) t)
                 #+sbcl
                 (when (item-idle-timer item)
                   ;; Release the lock once to prevent from deadlock
@@ -151,6 +150,7 @@
                    (decf (pool-timeout-in-queue-count pool)))
                   ((or (null ping)
                        (funcall ping (item-object item)))
+                   (setf (item-active-p item) t)
                    (incf (pool-active-count pool))
                    (return (item-object item)))
                   ;; Not available anymore. Just ignore

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -140,7 +140,6 @@
                    (bt:acquire-lock lock))))
               (let ((item (dequeue storage)))
                 (setf (item-active-p item) t)
-                (incf (pool-active-count pool))
                 #+sbcl
                 (when (item-idle-timer item)
                   ;; Release the lock once to prevent from deadlock
@@ -152,6 +151,7 @@
                    (decf (pool-timeout-in-queue-count pool)))
                   ((or (null ping)
                        (funcall ping (item-object item)))
+                   (incf (pool-active-count pool))
                    (return (item-object item)))
                   ;; Not available anymore. Just ignore
                   (t)))))))))


### PR DESCRIPTION
## Problem

If equal max-open-count and threads then it expected to success calling fetch everytime.
But sometime too-meny-open-connection is thrown if number of idle-timeout unittest loops (ex. 1000000) increases.

## Cause

active-count increment if timeout item.

## Solution

active-count increment only if return object.
