### PR TITLE
Fix the behavior of :timeout nil to wait forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Return the number of currently idle connections.
 
 Return an available resource from the `pool`. If no open resources available, it makes a new one with a function specified to `make-pool` as `:connector`.
 
-No open resource available and can't open due to the `max-open-count`, this function waits for `:timeout` milliseconds. If `:timeout` specified to `nil`, this throws `too-many-open-connection` condition.
+No open resource available and can't open due to the `max-open-count`, this function waits for `:timeout` milliseconds. If `:timeout` specified to `nil`, this waits forever until a new one turns to available.
 
 ### [Function] putback (object pool)
 

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -66,6 +66,17 @@
       (ok (= (pool-active-count pool) 0))
       (ok (= (pool-idle-count pool) 1)))))
 
+#|
+(deftest wait-forever
+  (let ((pool (make-pool :name "test pool"
+                         :connector #'get-internal-real-time
+                         :max-open-count 1
+                         :timeout nil)))
+    (fetch pool)
+    (fetch pool)
+    (fail "wait forever")))
+|#
+
 (deftest ping
   (let ((pool (make-pool :name "test pool"
                          :connector (lambda () (get-internal-real-time))


### PR DESCRIPTION
Fix the behavior of :timeout nil to wait forever from throwing too-many-open-connection condition.

close #2