### PR TITLE
Don't increment the active counter before allocating a new instance

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -118,8 +118,8 @@
           (if (zerop (pool-idle-count pool))
               (cond
                 ((can-open-p)
-                 (incf (pool-active-count pool))
-                 (return (allocate-new)))
+                 (return (prog1 (allocate-new)
+                           (incf (pool-active-count pool)))))
                 ((and (numberp timeout)
                       (zerop timeout))
                  (error 'too-many-open-connection


### PR DESCRIPTION
This ensures we don't count a non-existent instance as "used" when the connector function exits non-locally.