### PR TITLE
Fix race condition in SBCL idle timer handling

### DIFF
--- a/anypool.asd
+++ b/anypool.asd
@@ -15,7 +15,8 @@
                "anypool")
   :components
   ((:module "tests"
-    :components ((:file "main"))))
+    :components ((:file "utils")
+                 (:file "main" :depends-on ("utils")))))
   :perform (test-op (o c) (symbol-call :rove '#:run c)))
 
 (defsystem "anypool/middleware"

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -212,7 +212,7 @@
     #+sbcl
     (when (item-idle-timer item)
       ;; Mark as active BEFORE releasing lock to prevent race condition
-      ;; active-p is also true when timeout or ping failure, but those item objects are discarded, so there is no practical problem.
+      ;; active-p is set to true even for timed-out items or ping failures, but these items are discarded so this is harmless
       (setf (item-active-p item) t)
       ;; Release the lock once to prevent from deadlock
       (bt2:release-lock lock)

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -212,6 +212,7 @@
     #+sbcl
     (when (item-idle-timer item)
       ;; Mark as active BEFORE releasing lock to prevent race condition
+      ;; active-p is also true when timeout or ping failure, but those item objects are discarded, so there is no practical problem.
       (setf (item-active-p item) t)
       ;; Release the lock once to prevent from deadlock
       (bt2:release-lock lock)
@@ -222,7 +223,6 @@
        (decf (pool-timeout-in-queue-count pool)))
       ((or (null ping)
            (funcall ping (item-object item)))
-       ;; active-p is already set above
        (incf (pool-active-count pool))
        (return (item-object item)))
       ;; Not available anymore. Just ignore

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -52,7 +52,7 @@
   idle-timeout
   timeout
   ;; Internal
-  storage
+  storage ; queue object
   (active-count 0 :type fixnum)
   (lock (bt2:make-lock :name "ANYPOOL-LOCK"))
   (wait-lock (bt2:make-lock :name "ANYPOOL-OPENWAIT-LOCK"))
@@ -206,11 +206,13 @@
     :thread t))
 
 (define-fetch-impl %fetch-with-timeout pool-with-timeout
-  :idle-check (zerop (pool-idle-count pool))
+  :idle-check (<= (pool-idle-count pool) 0) ; Fail-safe for cases where pool-idle-count is negative
   :dequeue-and-validate
   (let ((item (dequeue storage)))
     #+sbcl
     (when (item-idle-timer item)
+      ;; Mark as active BEFORE releasing lock to prevent race condition
+      (setf (item-active-p item) t)
       ;; Release the lock once to prevent from deadlock
       (bt2:release-lock lock)
       (sb-ext:unschedule-timer (item-idle-timer item))
@@ -220,7 +222,7 @@
        (decf (pool-timeout-in-queue-count pool)))
       ((or (null ping)
            (funcall ping (item-object item)))
-       (setf (item-active-p item) t)
+       ;; active-p is already set above
        (incf (pool-active-count pool))
        (return (item-object item)))
       ;; Not available anymore. Just ignore
@@ -280,19 +282,19 @@
     (with-slots (idle-timeout) pool
       (setf (item-idle-timer item)
             (make-idle-timer item
-                            (lambda (conn)
-                              (let ((activep
-                                      (bt2:with-lock-held (lock)
-                                        (let ((activep (item-active-p item)))
-                                          (unless activep
-                                            (setf (item-timeout-p item) t)
-                                            (incf (pool-timeout-in-queue-count pool)))
-                                          activep))))
-                                (unless activep
-                                  (when disconnector
-                                    (funcall disconnector conn)))))))
+                             (lambda (conn)
+                               (let ((activep
+                                       (bt2:with-lock-held (lock)
+                                         (let ((activep (item-active-p item)))
+                                           (unless activep
+                                             (setf (item-timeout-p item) t)
+                                             (incf (pool-timeout-in-queue-count pool)))
+                                           activep))))
+                                 (unless activep
+                                   (when disconnector
+                                     (funcall disconnector conn)))))))
       (sb-ext:schedule-timer (item-idle-timer item)
-                            (/ idle-timeout 1000d0)))
+                             (/ idle-timeout 1000d0)))
     (enqueue item storage)))
 
 (defun putback (conn pool)

--- a/tests/utils.lisp
+++ b/tests/utils.lisp
@@ -1,0 +1,32 @@
+(defpackage #:anypool/tests/utils
+  (:use #:cl)
+  (:export #:*mock-function*
+           #:with-mock-functions))
+(in-package #:anypool/tests/utils)
+
+(defvar *mock-function*)
+
+#+sbcl
+(defun call-with-mock-function (fn-name fn main)
+  (let ((*mock-function* (if (boundp '*mock-function*)
+                             *mock-function*
+                             (make-hash-table :test 'eq)))
+        (orig-fn (symbol-function fn-name)))
+    (unwind-protect (progn
+                      (setf (gethash fn-name *mock-function*) orig-fn)
+                      (sb-ext:without-package-locks
+                        (setf (symbol-function fn-name) fn))
+                      (funcall main))
+      (sb-ext:without-package-locks
+        (setf (symbol-function fn-name) orig-fn))
+      (remhash fn-name *mock-function*))))
+
+(defmacro with-mock-functions ((&rest functions) &body body)
+  (if functions
+      (destructuring-bind (name &rest fn-body)
+          (first functions)
+        `(call-with-mock-function ',name (lambda ,@fn-body)
+                                  (lambda ()
+                                    (declare (notinline ,name))
+                                    (with-mock-functions (,@(rest functions)) ,@body))))
+      `(progn ,@body)))


### PR DESCRIPTION
issue: https://github.com/fukamachi/anypool/issues/4

This PR resolves a race condition that causes the connection pool to reach an inconsistent state (specifically, a negative idle count) when running on SBCL with `idle-timeout` enabled.

#### Problem
In `%fetch-with-timeout` (SBCL path), the pool lock is temporarily released to safely call `sb-ext:unschedule-timer` and avoid deadlocks. However, if the idle timer fires precisely during this unlocked window:
1. The `fetch` thread has already dequeued the item.
2. The timer thread acquires the lock, observes the item as inactive, and marks it as timed out (incrementing `timeout-in-queue-count`).
3. This leads to an incorrect `idle-count` (e.g., -1).
4. Subsequent `fetch` operations mistakenly perceive the pool as having available resources and attempt to dequeue from an empty queue, resulting in a crash (`CL-SPEEDY-QUEUE::QUEUE-UNDERFLOW-ERROR`).

```mermaid
sequenceDiagram
  participant ThreadA as Thread A (Fetch Process)
  participant Lock as Pool Lock
  participant Queue as Queue (Storage)
  participant ThreadB as Thread B (Idle Timer)
  participant State as Pool State

  Note over ThreadA, State: [Initial State] Queue count: 1, Timeout count: 0 => Idle count: 1

  ThreadA->>Lock: Acquire Lock
  ThreadA->>Queue: Dequeue Item
  Note right of Queue: Queue count: 1 -> 0
  
  rect rgb(255, 220, 220)
  Note over ThreadA: ★Danger Zone: Temporarily released to avoid deadlock
  ThreadA->>Lock: Release Lock
  end

  rect rgb(220, 255, 220)
  Note over ThreadB: Timer interrupts here!
  ThreadB->>Lock: Acquire Lock
  Note over ThreadB: Check item state
  Note over ThreadB: active-p is still NIL (ThreadA hasn't updated yet)
  ThreadB->>State: Mark as timeout
  ThreadB->>State: Increment TimeoutCount
  Note right of State: Timeout count: 0 -> 1
  ThreadB->>Lock: Release Lock
  end

  ThreadA->>Lock: Re-acquire Lock
  Note over ThreadA: Should set active-p=T here, but it's too late
  
  Note over State: [Result]<br/>Idle count = Queue(0) - Timeout(1) = -1
  
  Note over ThreadA, State: When next Fetch arrives, since Idle count(-1) != 0,<br/>it's misidentified as "idle available" and tries to pull from empty queue causing error
```

#### Solution
1. **Mark item as active early**: The item is now marked as active (`(setf (item-active-p item) t)`) *before* releasing the lock to unschedule the timer. Even if the timer thread interrupts, it will see `active-p` is `T` and abort the timeout logic, preventing the state corruption.
2. **Robust idle check**: Updated the idle availability check from `zerop` to `<= 0`. This serves as a secondary defense to ensure the pool degrades gracefully (by creating new connections) rather than crashing if the count were to become inconsistent.

This ensures thread safety during the interaction between the fetcher and the idle timer.